### PR TITLE
Added method to access Future[Result]

### DIFF
--- a/sample/app/controllers/Application.scala
+++ b/sample/app/controllers/Application.scala
@@ -6,7 +6,7 @@ import views._
 import controllers.stack._
 import jp.t2v.lab.play2.stackc.RequestWithAttributes
 
-object Application extends Controller with DBSessionElement {
+object Application extends Controller with DBSessionElement with LoggingElement {
   
   def index = Action {
     Ok(views.html.index("Your new application is ready."))

--- a/sample/app/controllers/stack/LoggingElement.scala
+++ b/sample/app/controllers/stack/LoggingElement.scala
@@ -1,0 +1,19 @@
+package controllers.stack
+
+import play.api.mvc.{Result, Controller}
+import jp.t2v.lab.play2.stackc.{RequestWithAttributes, RequestAttributeKey, StackableController}
+import jp.t2v.lab.play2.stackc.StackableController
+import play.api.Logger
+
+trait LoggingElement extends StackableController {
+    self: Controller =>
+
+  override def cleanupOnSucceeded[A](req: RequestWithAttributes[A], res: Option[Result]): Unit = {
+      res.map { result =>
+        Logger.debug(Array(result.header.status, req.toString(), req.body).mkString("\t"))
+      }
+      super.cleanupOnSucceeded(req, res)
+  }
+
+}
+


### PR DESCRIPTION
Because there is no way to use Future[Result] in StackableController, I added a method having request and result as arguments.

It is only Action(ActionBuilder) which is able to access both parsed request body and result. So I believe it is useful in some cases.