### PR TITLE
Added function using unicode arrow.

### DIFF
--- a/core/src/main/scala/jp/t2v/lab/play2/stackc/StackableController.scala
+++ b/core/src/main/scala/jp/t2v/lab/play2/stackc/StackableController.scala
@@ -54,6 +54,8 @@ trait RequestAttributeKey[A] {
 
   def ->(value: A): Attribute[A] = Attribute(this, value)
 
+  def →(value: A): Attribute[A] = Attribute(this, value)
+
 }
 
 case class Attribute[A](key: RequestAttributeKey[A], value: A) {


### PR DESCRIPTION
If you're using a tool like scalariform with the unicode arrows option
set or simply tend to use unicode arrows in your project then the
compiler will throw an error.

With the function being present as `->` and as `→` this should work now.